### PR TITLE
Fix https://bugs.gentoo.org/show_bug.cgi?id=500942

### DIFF
--- a/init.d/net.lo.in
+++ b/init.d/net.lo.in
@@ -203,7 +203,7 @@ _program_available()
 			/*) [ -x "${x}" ] && break;;
 			*) type "${x}" >/dev/null 2>&1 && break;;
 		esac
-		unset x
+		x=
 	done
 	[ -n "${x}" ] && echo $x && return 0
 	return 1


### PR DESCRIPTION
“unset x” also removes the “local x” property, so the next assignment and/or read to/from $x will access the global variable “x”.
