### PR TITLE
firewalld: remove use of OpenRC need function

### DIFF
--- a/net/firewalld.sh
+++ b/net/firewalld.sh
@@ -6,7 +6,6 @@ firewalld_depend()
 	after interface
 	before dhcp
 	program firewall-cmd
-	[ "$IFACE" != "lo" ] && need firewalld
 }
 
 _config_vars="$_config_vars firewalld_zone"


### PR DESCRIPTION
You can't use OpenRC's dependency functions in module depend functions,
because they aren't called in the OpenRC init script's depend function.
System administrators are responsible for ensuring that the dependencies
for their configuration are set correctly via (for OpenRC)
/etc/conf.d/net.