### PR TITLE
functions.sh: fix check for OpenRC

### DIFF
--- a/sh/functions.sh
+++ b/sh/functions.sh
@@ -16,7 +16,7 @@ else
 fi
 
 # runscript functions
-if [ -z "$(command -v service_set_value >/dev/null 2>&1)" ]; then
+if [ "$INIT" != "openrc" ]; then
 
 	# OpenRC functions used in depend
 	after() {


### PR DESCRIPTION
Fix the check for OpenRC so that it actually matches whether it's
running under OpenRC.

Reported-By: Patrick McLean <chutzpah@gentoo.org>