### PR TITLE
fix https://bugs.gentoo.org/show_bug.cgi?id=536758

### DIFF
--- a/sh/functions.sh
+++ b/sh/functions.sh
@@ -33,11 +33,14 @@ if [ -z "$(command -v service_set_value >/dev/null 2>&1)" ]; then
 	}
 
 	shell_var() {
-		local output=$1 sanitized_arg=
-		shift 1
+		local output= sanitized_arg=
 		for arg; do
 			sanitized_arg="${arg//[^a-zA-Z0-9_]/_}"
-			output="$output $arg"
+			if [ x"$output" = x"" ] ; then
+				output=$sanitized_arg
+			else
+				output="$output $sanitized_arg"
+			fi
 		done
 		echo "$output"
 	}


### PR DESCRIPTION
The shell version of shell_var is not correctly escaping vars