### PR TITLE
net: bridge: support iproute2 without emulation

### DIFF
--- a/doc/net.example.Linux.in
+++ b/doc/net.example.Linux.in
@@ -919,9 +919,9 @@
 # You can also configure the bridge or bridge members via sysfs on 2.6 kernels
 # or newer. See the kernel bridge documentation for a description of these
 # options.
-#stp_state_br0="0"
-#forward_delay_br0="10"
-#hairpin_mode_eth0="1"
+#bridge_stp_state_br0="0"
+#bridge_forward_delay_br0="10"
+#brport_hairpin_mode_eth0="1"
 
 #-----------------------------------------------------------------------------
 # RFC 2684 Bridge Support

--- a/doc/net.example.Linux.in
+++ b/doc/net.example.Linux.in
@@ -893,6 +893,7 @@
 # ports to it you must set at least one of the following variables based on the
 # interface name, so that we can pick it up from your configuration. Even an
 # empty value variable is fine, but at least one of them must be set:
+# bridge_force_IFVAR
 # brctl_IFVAR
 
 # You need to configure the ports to null values so dhcp does not get started

--- a/doc/net.example.Linux.in
+++ b/doc/net.example.Linux.in
@@ -910,6 +910,7 @@
 
 # Below is an example of configuring the bridge
 # Consult "man brctl" for more details
+# This method is deprecated in favour of the sysfs interface.
 #brctl_br0="setfd 15
 #sethello 2
 #stp on"

--- a/net/bridge.sh
+++ b/net/bridge.sh
@@ -82,16 +82,20 @@ bridge_pre_start()
 	# Old configuration set mechanism
 	# Only a very limited subset of the options are available in the old
 	# configuration method. The sysfs interface is in the next block instead.
-	local IFS="$__IFS"
-	for x in ${opts}; do
+	if [ -n "${opts}" ]; then
+		ewarn "brctl options are deprecated please migrate to sysfs options"
+		ewarn "map of important options is available at https://wiki.gentoo.org/wiki/Netifrc/Brctl_Migration"
+		local IFS="$__IFS"
+		for x in ${opts}; do
+			unset IFS
+			set -- ${x}
+			x=$1
+			shift
+			set -- "${x}" "${IFACE}" "$@"
+			brctl "$@"
+		done
 		unset IFS
-		set -- ${x}
-		x=$1
-		shift
-		set -- "${x}" "${IFACE}" "$@"
-		brctl "$@"
-	done
-	unset IFS
+	fi
 
 	# New configuration set mechanism, matches bonding
 	for x in /sys/class/net/"${IFACE}"/bridge/*; do

--- a/net/bridge.sh
+++ b/net/bridge.sh
@@ -125,12 +125,15 @@ bridge_pre_start()
 	for x in /sys/class/net/"${IFACE}"/bridge/*; do
 		[ -f "${x}" ] || continue
 		n=${x##*/}
-		eval s=\$${n}_${IFVAR}
-		if [ -n "${s}" ]; then
-			einfo "Setting ${n}: ${s}"
-			echo "${s}" >"${x}" || \
-			eerror "Failed to configure $n (${n}_${IFVAR})"
-		fi
+		# keep no prefix for backward compatibility
+		for prefix in "" bridge_; do
+			eval s=\$${prefix}${n}_${IFVAR}
+			if [ -n "${s}" ]; then
+				einfo "Setting ${n}: ${s}"
+				echo "${s}" >"${x}" || \
+				eerror "Failed to configure $n (${n}_${IFVAR})"
+			fi
+		done
 	done
 
 	if [ -n "${ports}" ]; then
@@ -161,12 +164,14 @@ bridge_pre_start()
 			for x in /sys/class/net/"${IFACE}"/brport/*; do
 				[ -f "${x}" ] || continue
 				n=${x##*/}
-				eval s=\$${n}_${IFVAR}
-				if [ -n "${s}" ]; then
-					einfo "Setting ${n}@${IFACE}: ${s}"
-					echo "${s}" >"${x}" || \
-					eerror "Failed to configure $n (${n}_${IFVAR})"
-				fi
+				for prefix in "" brport_; do
+					eval s=\$${prefix}${n}_${IFVAR}
+					if [ -n "${s}" ]; then
+						einfo "Setting ${n}@${IFACE}: ${s}"
+						echo "${s}" >"${x}" || \
+						eerror "Failed to configure $n (${n}_${IFVAR})"
+					fi
+				done
 			done
 			eend 0
 		done

--- a/net/bridge.sh
+++ b/net/bridge.sh
@@ -4,7 +4,7 @@
 bridge_depend()
 {
 	before interface macnet
-	program ip brctl
+	program brctl
 }
 
 _config_vars="$_config_vars bridge bridge_add brctl"
@@ -27,83 +27,6 @@ _bridge_ports()
 		n=${x##*/}
 		echo $n
 	done
-}
-
-_brctl()
-{
-	if [ -z "${_bridge_use_ip}" ]; then
-	       if ip -V >/dev/null 2>&1 && [ "$(ip -V | cut -c 24-29)" -ge 130430 ]; then
-			_bridge_use_ip=1
-		else
-			_bridge_use_ip=0
-		fi
-	fi
-	if [ "${_bridge_use_ip}" -eq 1 ]; then
-		case "$1" in
-			addbr)
-				ip link add "$2" type bridge
-				;;
-			delbr)
-				ip link del "$2"
-				;;
-			addif)
-				ip link set "$3" master "$2"
-				;;
-			delif)
-				ip link set "$3" nomaster
-				;;
-			setageing)
-				echo "$3" > /sys/class/net/"$2"/bridge/ageing_time
-				;;
-			setgcint)
-				# appears to have been dropped in Debian, and I don't see a sysfs file for it
-				eerror "brctl setgcint is not supported!"
-				return 1
-				;;
-			stp)
-				if [ "$3" = "on" -o "$3" = "yes" -o "$3" = "1" ]; then
-					_stp_state=1
-				elif [ "$3" = "off" -o "$3" = "no" -o "$3" = "0" ]; then
-					_stp_state=0
-				else
-					eerror "Invalid STP state for brctl stp!"
-					return 1
-				fi
-				echo ${_stp_state} > /sys/class/net/"$2"/bridge/stp_state
-				;;
-			setbridgeprio)
-				echo "$3" > /sys/class/net/"$2"/bridge/priority
-				;;
-			setfd)
-				echo "$3" > /sys/class/net/"$2"/bridge/forward_delay
-				;;
-			sethello)
-				echo "$3" > /sys/class/net/"$2"/bridge/hello_time
-				;;
-			setmaxage)
-				echo "$3" > /sys/class/net/"$2"/bridge/max_age
-				;;
-			setpathcost)
-				echo "$4" > /sys/class/net/"$2"/brif/"$3"/path_cost
-				;;
-			setportprio)
-				echo "$4" > /sys/class/net/"$2"/brif/"$3"/priority
-				;;
-			hairpin)
-				if [ "$4" -eq "on" -o "$4" -eq "yes" -o "$4" -eq "1" ]; then
-					_hairpin_mode=1
-				elif [ "$4" -eq "off" -o "$4" -eq "no" -o "$4" -eq "0" ]; then
-					_hairpin_mode=0
-				else
-					eerror "Invalid hairpin mode for brctl hairpin!"
-					return 1
-				fi
-				echo ${_hairpin_mode} > /sys/class/net/"$2"/brif/"$3"/hairpin_mode
-				;;
-		esac
-	else
-		brctl "$@"
-	fi
 }
 
 bridge_pre_start()
@@ -147,7 +70,7 @@ bridge_pre_start()
 
 	if ! _is_bridge ; then
 		ebegin "Creating bridge ${IFACE}"
-		if ! _brctl addbr "${IFACE}"; then
+		if ! brctl addbr "${IFACE}"; then
 			eend 1
 			return 1
 		fi
@@ -166,7 +89,7 @@ bridge_pre_start()
 		x=$1
 		shift
 		set -- "${x}" "${IFACE}" "$@"
-		_brctl "$@"
+		brctl "$@"
 	done
 	unset IFS
 
@@ -197,7 +120,7 @@ bridge_pre_start()
 			fi
 			# The interface is known to exist now
 			_up
-			if ! _brctl addif "${BR_IFACE}" "${x}"; then
+			if ! brctl addif "${BR_IFACE}" "${x}"; then
 				eend 1
 				return 1
 			fi
@@ -253,13 +176,13 @@ bridge_post_stop()
 		ebegin "Removing port ${port}${extra}"
 		local IFACE="${port}"
 		_set_flag -promisc
-		_brctl delif "${iface}" "${port}"
+		brctl delif "${iface}" "${port}"
 		eend $?
 	done
 
 	if ${delete}; then
 		eoutdent
-		_brctl delbr "${iface}"
+		brctl delbr "${iface}"
 		eend $?
 	fi
 


### PR DESCRIPTION
Hello,

This revert the great work of Doug Freed in favour of a simpler approach.

The approach Doug has taken is to emulate the legacy brctl, while we usually do not emulate legacy utilities specific behaviour  in netifrc see tuntap or wireless.

So as much as I appreciate the work, I think a simpler method that leverage the new sysfs interface and enable removal of brctl in future without pushing it into newer installations is better for netifrc.

Thanks,
Alon