### PR TITLE
net.lo: use #!/sbin/openrc-run instead of #!/sbin/runscript

### DIFF
--- a/init.d/net.lo.in
+++ b/init.d/net.lo.in
@@ -1,6 +1,6 @@
-#!@SBINDIR@/runscript
+#!@SBINDIR@/openrc-run
 # Copyright (c) 2007-2009 Roy Marples <roy@marples.name>
-# Copyright (c) 2010-2015 Gentoo Foundation
+# Copyright (c) 2010-2016 Gentoo Foundation
 # Released under the 2-clause BSD license.
 
 SHDIR="@LIBEXECDIR@/sh"


### PR DESCRIPTION
See: https://bugs.gentoo.org/573846