### PR TITLE
add a configurable presence timeout

### DIFF
--- a/doc/net.example.BSD.in
+++ b/doc/net.example.BSD.in
@@ -77,6 +77,22 @@
 # Some users may need to alter the MTU - here's how
 #mtu_eth0="1500"
 
+# Sometimes you may want to wait for a particular interface to show up
+# when starting its service.
+# For example if a net.foo service is in the "default" runlevel so it
+# provides (or co-provides) the "net" service and it takes a while for the
+# "foo" interface to initialize and show up in the system during a boot this
+# will race with starting of net.foo service by the service manager - if the
+# interface hasn't shown up yet the service won't be able start (and so
+# will services that depend on it).
+# This setting specifies how long we wait for an interface to show up
+# in this case (in seconds).
+# The current default is 0 - we need an interface to be already present
+# in the system when its service is started.
+#presence_timeout=0
+# This setting can be also adjusted on a per-interface basis:
+#presence_timeout_eth0=10
+
 # Most drivers that report carrier status function correctly, but some do not
 # One of these faulty drivers is for the Intel e1000 network card, but only
 # at boot time. To get around this you may alter the carrier_timeout value for

--- a/doc/net.example.Linux.in
+++ b/doc/net.example.Linux.in
@@ -126,6 +126,22 @@
 # tables you may have to set a global metric as the due to a simple read of
 # the routing table taking over a minute at a time.
 
+# Sometimes you may want to wait for a particular interface to show up
+# when starting its service.
+# For example if a net.foo service is in the "default" runlevel so it
+# provides (or co-provides) the "net" service and it takes a while for the
+# "foo" interface to initialize and show up in the system during a boot this
+# will race with starting of net.foo service by the service manager - if the
+# interface hasn't shown up yet the service won't be able start (and so
+# will services that depend on it).
+# This setting specifies how long we wait for an interface to show up
+# in this case (in seconds).
+# The current default is 0 - we need an interface to be already present
+# in the system when its service is started.
+#presence_timeout=0
+# This setting can be also adjusted on a per-interface basis:
+#presence_timeout_eth0=10
+
 # Most drivers that report carrier status function correctly, but some do not
 # One of these faulty drivers is for the Intel e1000 network card, but only
 # at boot time. To get around this you may alter the carrier_timeout value for

--- a/init.d/net.lo.in
+++ b/init.d/net.lo.in
@@ -118,6 +118,37 @@ _flatten_array()
 	_array_helper $1
 }
 
+_wait_for_presence()
+{
+	local timeout=
+	local rc=
+
+	_exists && return 0
+
+	eval timeout=\$presence_timeout_${IFVAR}
+	timeout=${timeout:-${presence_timeout:-0}}
+
+	[ ${timeout} -le 0 ] && return 1
+
+	einfon "Waiting for ${IFACE} to show up (${timeout} seconds)"
+	while [ ${timeout} -gt 0 ]; do
+		_exists
+		rc=$?
+		[ $rc -eq 0 ] && break
+
+		sleep 1
+		printf "."
+		: $(( timeout -= 1 ))
+	done
+
+	if [ ${timeout} -le 0 ]; then
+		_exists
+		rc=$?
+	fi
+	echo
+	eend $rc
+}
+
 _wait_for_carrier()
 {
 	local timeout=
@@ -618,7 +649,7 @@ start()
 		fi
 	done
 
-	if ! _exists; then
+	if ! _wait_for_presence; then
 		eerror "ERROR: interface ${IFACE} does not exist"
 		eerror "Ensure that you have loaded the correct kernel module for your hardware"
 		return 1


### PR DESCRIPTION
Sometimes one may want to wait for a particular interface to show up
when starting its service.
For example if a "net.foo" service is in the "default" runlevel so it
provides (or co-provides) the "net" service and it takes a while for the
"foo" interface to initialize and show up in the system during boot this
interface initialization will race with starting of this "net.foo" service
by the service manager - if the interface hasn't shown up yet the service
won't be able to start (and so will services that depend on it).

This setting specifies how long we'll wait for an interface to show up
in this case (in seconds).
For backward-compatibility the default is 0 (don't wait at all) - this
matches the existing behavior of netifrc, so existing deployments aren't
affected by this change.

This new setting is similar to an already present "wait for carrier
timeout" setting.
