### PR TITLE
systemd should not fail if a service is backgrounding

### DIFF
--- a/systemd/net_at.service.in
+++ b/systemd/net_at.service.in
@@ -5,6 +5,7 @@ Description=Gentoo Network Interface Management Scripts
 Type=oneshot
 ExecStart=@LIBEXECDIR@/sh/systemd-wrapper.sh -i %I start
 ExecStop=@LIBEXECDIR@/sh/systemd-wrapper.sh -i %I stop
+SuccessExitStatus=1
 RemainAfterExit=yes
 
 [Install]


### PR DESCRIPTION
To achieve this, accept 1 (backgrounding) as a valid exit code.
An alternative might be to return 0 (or a different exit code which
is accepted) for background operations like e.g. in line 181 of
net/wpa_supplicant.sh