### PR TITLE
sh/functions.sh: Avoid bashisms in shell_var()

### DIFF
--- a/sh/functions.sh
+++ b/sh/functions.sh
@@ -36,7 +36,15 @@ if [ "$INIT" != "openrc" ]; then
 	shell_var() {
 		local output= sanitized_arg=
 		for arg; do
-			sanitized_arg="${arg//[^a-zA-Z0-9_]/_}"
+			sanitized_arg=$arg
+			while :; do
+				case $sanitized_arg in
+				*[!a-zA-Z0-9_]*)
+					sanitized_arg=${sanitized_arg%%[!a-zA-Z0-9_]*}_${sanitized_arg#*[!a-zA-Z0-9_]}
+					continue;;
+				esac
+				break
+			done
 			if [ x"$output" = x"" ] ; then
 				output=$sanitized_arg
 			else


### PR DESCRIPTION
POSIX shells do not provide a substitution operation ${..//..}
Negated character classes are marked by [!..] and not [^..] in POSIX.