### PR TITLE
Added macvtap support

### DIFF
--- a/doc/net.example.Linux.in
+++ b/doc/net.example.Linux.in
@@ -664,6 +664,9 @@
 # MAC-VLAN mode (private, vepa, bridge, passtru)
 #mode_macvlan0="private"
 
+# MAC-VLAN type (macvlan, macvtap)
+#type_macvlan0="macvtap"
+
 # IP address, MAC address, ... are configured as a normal interface
 #config_macvlan0="192.168.20.20/24"
 #mac_macvlan0="00:50:06:20:20:20"

--- a/net/macvlan.sh
+++ b/net/macvlan.sh
@@ -34,8 +34,12 @@ macvlan_pre_start()
 	eval mode=\$mode_${IFVAR}
 	[ -z "${mode}" ] && mode="private"
 
+	local type=
+	eval type=\$type_${IFVAR}
+	[ -z "${type}" ] && type="macvlan"
+
 	ebegin "Creating MAC-VLAN ${IFACE} to ${macvlan}"
-	e="$(ip link add link "${macvlan}" name "${IFACE}" type macvlan mode "${mode}" 2>&1 1>/dev/null)"
+	e="$(ip link add link "${macvlan}" name "${IFACE}" type "${type}" mode "${mode}" 2>&1 1>/dev/null)"
 	if [ -n "${e}" ]; then
 		eend 1 "${e}"
 	else
@@ -49,6 +53,6 @@ macvlan_post_stop()
 	_is_macvlan || return 0
 
 	ebegin "Removing MAC-VLAN ${IFACE}"
-	ip link delete "${IFACE}" type macvlan >/dev/null
+	ip link delete "${IFACE}" >/dev/null
 	eend $?
 }


### PR DESCRIPTION
Edit is trivial. It should not break existing configs as default value is the same as before.
The naming might be slightly confusing but from my understanding macv**tap** is a macv**lan** exposed as TAP device and as such they can be grouped together.