### PR TITLE
Correct pppd version check. Handle pppd plugins

### DIFF
--- a/net/pppd.sh
+++ b/net/pppd.sh
@@ -23,7 +23,7 @@ requote()
 
 pppd_is_ge_248()
 {
-	local ver_str="$(/usr/sbin/pppd --version 2>&1 | grep -o '[[:digit:]\.]\+')"
+	local ver_str="$(/usr/sbin/pppd --version 2>&1 | grep 'pppd version' | grep -o '[[:digit:]\.]\+')"
 	local maj_ver="$(echo ${ver_str} | cut -d . -f 1)"
 	local min_ver="$(echo ${ver_str} | cut -d . -f 2)"
 	local patch_ver="$(echo ${ver_str} | cut -d . -f 3)"


### PR DESCRIPTION
The "pppd --version" call appears to also return details of initialisation
of plugins along with the version. These will often include "."s and so
confuse our version check. Could improve the specificity of the version
check grep, but simpler to just filter for the correct line