### PR TITLE
init.d/net.lo.in: Add missing closing function bracket

### DIFF
--- a/init.d/net.lo.in
+++ b/init.d/net.lo.in
@@ -295,6 +295,7 @@ _get_errorhandler_behavior() {
 			echo "$value" && break
 		fi
 	done
+}
 
 _show_address6()
 {


### PR DESCRIPTION
Bug introdcued with commit d3b5d78c5f3696aaf841d7900e69a37de29cfc25

Signed-off-by: Lars Wendler <polynomial-c@gentoo.org>