### PR TITLE
Add initial support for network namespaces

### DIFF
--- a/doc/net.example.Linux.in
+++ b/doc/net.example.Linux.in
@@ -1333,6 +1333,15 @@
 # Wireguard can also be configured by passing explicit settings
 #wireguard_wg0="private-key /path/to/whatever listen-port 1234 peer ABCDEF= endpoint 1.2.3.4:2468"
 
+# Network namespace support 
+# If an interface is configured with a network namespace, it will be moved
+# in to that namespace before being started. This does not have any functionality
+# to move interfaces out of network namespaces. The next time the interfaces is
+# started, it will simply start the interface inside the namespace.
+#
+# Note that not all functionality has been updated to work with network namespace
+#netns_eth0="mynetns"
+
 ##############################################################################
 # ADVANCED CONFIGURATION
 #

--- a/init.d/net.lo.in
+++ b/init.d/net.lo.in
@@ -660,6 +660,12 @@ start()
 		_load_modules true
 	fi
 
+	for module in ${MODULES}; do
+		if [ "$(command -v "${module}_pre_up")" = "${module}_pre_up" ]; then
+			${module}_pre_up || exit $?
+		fi
+	done
+
 	# We up the iface twice if we have a preup to ensure it's up if
 	# available in preup and afterwards incase the user inadvertently
 	# brings it down

--- a/net/dummy.sh
+++ b/net/dummy.sh
@@ -13,16 +13,20 @@ _is_dummy() {
 	is_interface_type dummy
 }
 
+_ip()
+{
+	veinfo ip "${@}"
+	_netns ip "${@}"
+}
+
 dummy_pre_start()
 {
 	local dummy=
-	eval dummy=\$type_${IFVAR}
+	eval dummy="\$type_${IFVAR}"
 	[ "${dummy}" = "dummy" ] || return 0
 
 	ebegin "Creating dummy interface ${IFACE}"
-	cmd="ip link add name "${IFACE}" type dummy"
-	veinfo $cmd
-	if $cmd ; then
+	if _ip link add name "${IFACE}" type dummy ; then
 		eend 0 && _up && set_interface_type dummy
 	else
 		eend 1
@@ -35,8 +39,6 @@ dummy_post_stop()
 	_is_dummy || return 0
 
 	ebegin "Removing dummy ${IFACE}"
-	cmd="ip link delete "${IFACE}" type dummy"
-	veinfo "$cmd"
-	$cmd
+	_ip link delete "${IFACE}" type dummy
 	eend $?
 }


### PR DESCRIPTION
This adds initial support for network namespaces. An interface can be assigned to a network namespace with `netns_${IFACE}`. The script will move the interface to the namespace if it is not already there.

This uses a generic `_netns` wrapper defined in functions.sh, this allows scripts to operate within network namespaces fairly easily.

This currently adds netns support to
* iproute2.sh
* bridge.sh
* bonding.sh
* dummy.sh

Currently only the basic iproute2 functionality is tested, the others are untested as most of them involve more setup than just a basic network interface.

This also fixes an issue where the BusyBox internal ip command would get used, and of course randomly break as it only supports a small subset of the real iproute2 version.