### PR TITLE
net/ethtool.sh: add "eee" and "tunable" setting operations

### DIFF
--- a/doc/net.example.Linux.in
+++ b/doc/net.example.Linux.in
@@ -1275,7 +1275,7 @@
 #ethtool_pause_eth0="autoneg off
 #rx on tx on"
 
-# Enasble adaptive RX and TX coalescing
+# Enable adaptive RX and TX coalescing
 #ethtool_coalesce_eth0="adaptive-rx on adaptive-tx on"
 
 # Change ring buffer settings

--- a/doc/net.example.Linux.in
+++ b/doc/net.example.Linux.in
@@ -1275,11 +1275,17 @@
 #ethtool_pause_eth0="autoneg off
 #rx on tx on"
 
+# Enable Energy-Efficient Ethernet
+#ethtool_eee_eth0="eee on"
+
 # Enable adaptive RX and TX coalescing
 #ethtool_coalesce_eth0="adaptive-rx on adaptive-tx on"
 
 # Change ring buffer settings
 #ethtool_ring_eth0=""
+
+# Set RX copy-break at 1500 bytes
+#ethtool_tunable_eth0="rx-copybreak 1500"
 
 # Enable all offload settings
 #ethtool_offload_eth0="rx on tx on sg on tso on ufo on gso on gro on lro on"
@@ -1309,13 +1315,13 @@
 
 # Additionally, there is a special control variable, if you need to change the
 # order of option processing. The default order is:
-# flash change-eeprom change pause coalesce ring offload identify nfc rxfh-indir ntuple
+# flash change-eeprom change pause eee coalesce ring offload tunable identify nfc rxfh-indir ntuple
 
 # Set global order to default
-#ethtool_order="flash change-eeprom change pause coalesce ring offload identify nfc rxfh-indir ntuple"
+#ethtool_order="flash change-eeprom change pause eee coalesce ring offload tunable identify nfc rxfh-indir ntuple"
 
 # Hypothetical network card that requires a change-eeprom toggle to enable flashing
-#ethtool_order_eth0="change-eeprom flash change pause coalesce ring offload nfc rxfh-indir ntuple"
+#ethtool_order_eth0="change-eeprom flash change pause eee coalesce ring offload tunable nfc rxfh-indir ntuple"
 
 #-----------------------------------------------------------------------------
 # Firewalld support

--- a/net/ethtool.sh
+++ b/net/ethtool.sh
@@ -17,7 +17,7 @@ ethtool_pre_start() {
 	local order opt OFS="${OIFS}"
 	eval order=\$ethtool_order_${IFVAR}
 	[ -z "${order}" ] && eval order=\$ethtool_order
-	[ -z "${order}" ] && order="flash change-eeprom change pause coalesce ring offload identify nfc rxfh-indir ntuple"
+	[ -z "${order}" ] && order="flash change-eeprom change pause eee coalesce ring offload tunable identify nfc rxfh-indir ntuple"
 	# ethtool options not used: --driver, --register-dump, --eeprom-dump, --negotiate, --test, --statistics
 	eindent
 	for opt in ${order} ; do
@@ -36,7 +36,7 @@ ethtool_pre_start() {
 			local args_pretty="$(_trim "${p}")"
 			# Do nothing if empty
 			[ -z "${args_pretty}" ] && continue
-			[ "${opt}" = "ring" ] && opt="set-ring"
+			[ "${opt}" = "eee" -o "${opt}" = "ring" -o "${opt}" = "tunable" ] && opt="set-${opt}"
 			args_pretty="--${opt} $IFACE ${args_pretty}"
 			args="--${opt} $IFACE ${args}"
 			ebegin "ethtool ${args_pretty}"


### PR DESCRIPTION
This PR adds an ability to set "eee" and "tunable" ethtool parameters of a network interface (along with a small typo fix in the neighboring line).
