### PR TITLE
wireguard: arbitrary interface names support

### DIFF
--- a/doc/net.example.Linux.in
+++ b/doc/net.example.Linux.in
@@ -1350,6 +1350,10 @@
 #
 # Wireguard can also be configured by passing explicit settings
 #wireguard_wg0="private-key /path/to/whatever listen-port 1234 peer ABCDEF= endpoint 1.2.3.4:2468"
+#
+# You must specify wireguard interface type to use arbitrary interface names
+#wireguard_site1="/path/to/site1.conf"
+#type_site1="wireguard"
 
 # Network namespace support 
 # If an interface is configured with a network namespace, it will be moved

--- a/net/wireguard.sh
+++ b/net/wireguard.sh
@@ -9,9 +9,15 @@ wireguard_depend()
 	before interface
 }
 
+_is_wireguard() {
+	is_interface_type wireguard
+}
+
 wireguard_pre_start()
 {
-	[ "${IFACE#wg}" != "$IFACE" ] || return 0
+	local wireguard=
+	eval wireguard=\$type_${IFVAR}
+	[ "${wireguard}" = "wireguard" -o "${IFACE#wg}" != "$IFACE" ] || return 0
 
 	ip link delete dev "$IFACE" type wireguard 2>/dev/null
 	ebegin "Creating WireGuard interface $IFACE"
@@ -35,6 +41,7 @@ wireguard_pre_start()
 		e=$?
 		if [ $e -eq 0 ]; then
 			eend $e
+			set_interface_type wireguard
 			return $e
 		fi
 	fi
@@ -45,7 +52,7 @@ wireguard_pre_start()
 
 wireguard_post_stop()
 {
-	[ "${IFACE#wg}" != "$IFACE" ] || return 0
+	_is_wireguard || [ "${IFACE#wg}" != "$IFACE" ] || return 0
 
 	ebegin "Removing WireGuard interface $IFACE"
 	ip link delete dev "$IFACE" type wireguard

--- a/net/wireguard.sh
+++ b/net/wireguard.sh
@@ -5,7 +5,7 @@
 
 wireguard_depend()
 {
-	program wg
+	program ip wg
 	before interface
 }
 


### PR DESCRIPTION
Arbitrary interface names are useful in case of wireguard interface groups covered by different iptables wildcard matches.