### PR TITLE
dhcpcd: Adding the saved args to the stop command

### DIFF
--- a/net/dhcpcd.sh
+++ b/net/dhcpcd.sh
@@ -90,8 +90,8 @@ dhcpcd_stop()
 	eval opts=\$dhcp_${IFVAR}
 	[ -z "${opts}" ] && opts=${dhcp}
 	case " ${opts} " in
-		*" release "*) dhcpcd -k "${IFACE}" ;;
-		*) dhcpcd -x "${IFACE}" ;;
+		*" release "*) dhcpcd -k "${args}" "${IFACE}" ;;
+		*) dhcpcd -x "${args}" "${IFACE}" ;;
 	esac
 	[ -f "${argsfile}" ] && rm -f "${argsfile}"
 	eend $?


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/881039
Signed-off-by: Kevin Martin <kevinmbecause@gmail.com>