### PR TITLE
net/macchanger.sh 1.7.0_p5_p4-r1 location change

### DIFF
--- a/net/macchanger.sh
+++ b/net/macchanger.sh
@@ -64,7 +64,7 @@ macchanger_pre_start()
 		*) opts="${opts} -m ${mac}";;
 	esac
 
-	if [ ! -x /sbin/macchanger ]; then
+	if [ ! -x /usr/bin/macchanger ]; then
 		eerror "For changing MAC addresses, emerge net-analyzer/macchanger"
 		return 1
 	fi
@@ -72,7 +72,7 @@ macchanger_pre_start()
 	for try in 1 2; do
 		# Sometimes the interface needs to be up
 		[ "${try}" -eq 2 ] && _up
-		output=$(/sbin/macchanger ${opts} "${IFACE}")
+		output=$(/usr/bin/macchanger ${opts} "${IFACE}")
 		rc=$?
 		[ "${rc}" -eq 0 ] && break
 	done


### PR DESCRIPTION
https://bugs.gentoo.org/889922
https://bugs.gentoo.org/886121

Proposing changes from example diff attached to 889922.
As suggested in 889922, there could be multiple ways to fix...
"netifrc macchanger.sh script either needs to point to /usr/bin/macchanger rather than /sbin/macchanger (twice in script, one producing error above) or a link has to be made from /sbin/macchanger to /usr/bin/macchanger (probably not likely as it was moved out of 'sbin' for a reason? due 886121?) or ebuild install location change for macchanger"

net-analyzer/macchanger-1.7.0_p5_p4 to net-analyzer/macchanger-1.7.0_p5_p4-r1 changed softlink and binary location due to 886121, subsequent tidy up with net-analyzer/macchanger-1.7.0_p5_p4-r2.  Proposing here a macchanger.sh change to allow netifrc to work with macchanger changes.