### PR TITLE
iwd: depend on "program /usr/libexec/iwd" instead of "program iwd"

### DIFF
--- a/net/iwd.sh
+++ b/net/iwd.sh
@@ -7,7 +7,7 @@ iwd_depend()
 	before interface
 	provide wireless
 	after iwconfig
-	program iwd
+	program /usr/libexec/iwd
 }
 
 _config_vars="$_config_vars iwd"


### PR DESCRIPTION
In iwd.sh, the iwd executable used is /usr/libexec/iwd, however in the dependency block it depends on just "program iwd." Since iwd is not in PATH, this will fail and cause iwd to not be started when it should be. Correct this to /usr/libexec/iwd.