### PR TITLE
mk/os.mk: don't use OS env var for overriding

### DIFF
--- a/mk/os.mk
+++ b/mk/os.mk
@@ -5,7 +5,7 @@
 
 _OS_SH=		uname -s
 _OS:= 		$(shell ${_OS_SH})
-OS?= 		${_OS}
+OS= 		${_OS}
 include ${MK}/os-${OS}.mk
 
 RC_LIB=		/$(LIBNAME)/rc


### PR DESCRIPTION
If you want to override the OS or OS-detect command you can still use _OS and _OS_SH, but OS is too common of an environment variable to listen for.

Closes: https://bugs.gentoo.org/906171