### PR TITLE
net/wireguard.sh: make wireguard module to run before interface

### DIFF
--- a/net/wireguard.sh
+++ b/net/wireguard.sh
@@ -6,7 +6,7 @@
 wireguard_depend()
 {
 	program wg
-	after interface
+	before interface
 }
 
 wireguard_pre_start()


### PR DESCRIPTION
Wireguard module was configured to run after interface module, that caused interface-related settings like mtu not to apply, because wireguard interfaces was not present by that time. It seems logical that wireguard module should be run before interface module.

Credits to lmk <lmkrawiec@gmail.com> who proposed the solution and to Louis Sautier (sbraz) <sbraz@gentoo.org> who proposed the patch.

Closes: https://bugs.gentoo.org/678184