### PR TITLE
For bonding and bridges, disable IPv6 on slaves.

### DIFF
--- a/net/bonding.sh
+++ b/net/bonding.sh
@@ -133,6 +133,7 @@ bonding_pre_start()
 		for IFACE in ${slaves}; do
 			_delete_addresses
 			_down
+			sysctl "net.ipv6.conf.${IFACE//./\/}.disable_ipv6=1" # Disable v6: https://bugs.gentoo.org/515640
 		done
 	fi
 	)

--- a/net/bridge.sh
+++ b/net/bridge.sh
@@ -152,6 +152,7 @@ bridge_pre_start()
 				return 1
 			fi
 			# The interface is known to exist now
+			sysctl "net.ipv6.conf.${x//./\/}.disable_ipv6=1" # Disable v6: https://bugs.gentoo.org/515640
 			_up
 			if ${do_iproute2}; then
 				_netns ip link set "${x}" master "${BR_IFACE}"


### PR DESCRIPTION
I doubt this will work for BSD as well, so please advise a better strategy.

Closes: https://bugs.gentoo.org/515640