### PR TITLE
Implement ip-token(8) addressing for IPv6.

### DIFF
--- a/doc/net.example.Linux.in
+++ b/doc/net.example.Linux.in
@@ -106,6 +106,16 @@
 #config_eth0="192.168.0.2/24 scope host
 #4321:0:1:2:3:4:567:89ab/64 nodad home preferred_lft 0"
 
+# Tokenized IPv6 addressing (as per ip-token(8)) is also possible.  This will
+# grab the last 64 bits of the IP address below, and use that to auto-configure
+# IPv6 addresses, when using SLAAC.  For example, given ::dead:beef below and an
+# advertised prefix of 100::/64 then Linux will configure an IPv6 address of
+# 100::dead:beef/64 on the interface.  You can use "tail-end IPv4 addresses" too.
+#ip6token_eth0="::dead:beef"
+#ip6token_eth0="::192.168.0.1"
+#ip6token_eth0="::dead:beef:192.168.0.1"
+#ip6token_eth0="::ffff:192.168.0.1" # OK because the prefix won't be ::/64.
+
 # Here's how to do routing if you need it
 # We add an IPv4 default route, IPv4 subnet route and an IPv6 unicast route
 #routes_eth0="default via 192.168.0.1

--- a/net/ip6token.sh
+++ b/net/ip6token.sh
@@ -1,0 +1,25 @@
+# Copyright (c) 2024 Gentoo Authors
+
+ip6token_depend()
+{
+	program ip
+	after interface
+}
+
+_config_vars="$_config_vars ip6token"
+
+ip6token_pre_start()
+{
+	local tconfig
+	eval tconfig=\$ip6token_${IFVAR}
+
+	[ -z "${tconfig}" ] && return 0
+	ip token set "${tconfig}" dev "${IFACE}" 
+	return $?
+}
+
+ip6token_post_stop()
+{
+	ip token del dev "${IFACE}"
+	return $?
+}


### PR DESCRIPTION
This enables setting ip-token(8) up during pre-up from a config variable ip6token_${IFVAR} to set up tokens to be used during SLAAC auto-configuration.

Closes: https://bugs.gentoo.org/935280