### PR TITLE
net: iproute2: fix missing quotes in test

### DIFF
--- a/net/iproute2.sh
+++ b/net/iproute2.sh
@@ -290,7 +290,7 @@ _add_route()
 
 	# Process dev vs nodev routes
 	# Positional parameters are used for correct array handling
-	if [ -n ${rtype} ]; then
+	if [ -n "${rtype}" ]; then
 		local nodev_routes="$(service_get_value "nodev_routes")"
 		service_set_value "nodev_routes" "${nodev_routes}
 ${family} route del ${rtype} ${cmd}"


### PR DESCRIPTION
Missing quotes cause incorrect evaluation of an empty string, causing the expression to be always true. Thus every route is considered "nodev" route, causing problems in cases where specific dev is required.

Original "nodev" patch 7c6a8de0 contained bashism that forgave missing quoutes. But later it was fixed by 97a79cfd, and the missing quotes became critical.


Closes: https://bugs.gentoo.org/940443
X-Gentoo-Bug: 940443
X-Gentoo-Bug-URL: https://bugs.gentoo.org/940443