### PR TITLE
net: ip6token: remote token only if added

### DIFF
--- a/net/ip6token.sh
+++ b/net/ip6token.sh
@@ -20,6 +20,10 @@ ip6token_pre_start()
 
 ip6token_post_stop()
 {
+	local tconfig
+	eval tconfig=\$ip6token_${IFVAR}
+
+	[ -z "${tconfig}" ] && return 0
 	ip token del dev "${IFACE}"
 	return $?
 }


### PR DESCRIPTION
do not attempt to remote a token if not added (exists in configuration).

this also provide support for busybox which lacks the "ip token" applet.