### PR TITLE
net: iproute2: add support for ip link alias

### DIFF
--- a/net/iproute2.sh
+++ b/net/iproute2.sh
@@ -487,6 +487,14 @@ iproute2_pre_start()
 		eend $? || return 1
 		_up
 	fi
+	local alias=
+	eval alias=\$alias_${IFVAR}
+	if [ -n "${alias}" ]; then
+		ebegin "Setting ${IFVAR} alias to ${alias}"
+		_ip -v ${ipproto} link set "${IFACE}" alias "${alias}"
+		eend $? || return 1
+		_up
+	fi
 
 	# MTU support
 	local mtu=


### PR DESCRIPTION
ip link supports having an alias to an interface, so when we do ip link show, we know what this interface is used for, which is very interesting for systems with a lot of interfaces (eg. routers)